### PR TITLE
Hotfix/Break Out Recursion  Method in ExpiryDate

### DIFF
--- a/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
+++ b/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
@@ -21,11 +21,10 @@ public record ExpiryDate
         Year = value.Year;
     }
 
-    private ExpiryDate((int Month, int Year) values)
+    private ExpiryDate((int Month, int Year) values) : this(new DateTime(values.Year, values.Month, 1, 0, 0, 0, DateTimeKind.Local))
     {
         Month = values.Month;
         Year = values.Year;
-        Value = new DateTime(Year, Month, 1);
     }
 
     public string Formatted_ptBr()

--- a/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
+++ b/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
@@ -21,7 +21,7 @@ public record ExpiryDate
         Year = value.Year;
     }
 
-    public ExpiryDate((int Month, int Year) values)
+    private ExpiryDate((int Month, int Year) values)
     {
         Month = values.Month;
         Year = values.Year;

--- a/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
+++ b/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
@@ -33,4 +33,3 @@ public record ExpiryDate
         return $"{Value.Month:D2}/{Value.Year % 100:D2}";
     }
 }
-

--- a/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
+++ b/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
@@ -33,3 +33,4 @@ public record ExpiryDate
         return $"{Value.Month:D2}/{Value.Year % 100:D2}";
     }
 }
+

--- a/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
+++ b/LiteStreaming.Domain/Transactions/ValueObject/ExpiryDate.cs
@@ -5,20 +5,29 @@ public record ExpiryDate
 {
     public static implicit operator (int Month, int Year)(ExpiryDate expiryDate) => (expiryDate.Month, expiryDate.Year);
     public static implicit operator ExpiryDate((int Month, int Year) values) => new ExpiryDate(values);
+
     public DateTime Value { get; set; }
-    
+
     [NotMapped]
     public int Month { get; init; }
-    
+
     [NotMapped]
     public int Year { get; init; }
-   
+
     public ExpiryDate(DateTime value)
     {
         Value = value;
         Month = value.Month;
         Year = value.Year;
     }
+
+    public ExpiryDate((int Month, int Year) values)
+    {
+        Month = values.Month;
+        Year = values.Year;
+        Value = new DateTime(Year, Month, 1);
+    }
+
     public string Formatted_ptBr()
     {
         return $"{Value.Month:D2}/{Value.Year % 100:D2}";

--- a/LiteStreaming.XUnitTest/Domain/Transactions/ValueObject/ExpiryDateTest.cs
+++ b/LiteStreaming.XUnitTest/Domain/Transactions/ValueObject/ExpiryDateTest.cs
@@ -1,34 +1,88 @@
 ﻿using Domain.Transactions.ValueObject;
+using System.Globalization;
 
 namespace Domain.Transactions;
-public class ExpiryDateTest
+public class ExpiryDateTests
 {
     [Fact]
-    public void Should_Create_Instance_With_Valid_Value()
+    public void ImplicitConversionToTuple_ShouldReturnCorrectValues()
     {
         // Arrange
-        var validDate = new DateTime(2023, 12, 31);
+        var expiryDate = new ExpiryDate(new DateTime(2024, 6, 27));
 
         // Act
-        var expiryDate = new ExpiryDate(validDate);
+        (int Month, int Year) result = expiryDate;
 
         // Assert
-        Assert.Equal(validDate, expiryDate.Value);
-        Assert.Equal(validDate.Month, expiryDate.Month);
-        Assert.Equal(validDate.Year, expiryDate.Year);
+        Assert.Equal(6, result.Month);
+        Assert.Equal(2024, result.Year);
     }
 
     [Fact]
-    public void Should_Return_Correct_Formatted_ptBr()
+    public void ImplicitConversionFromTuple_ShouldCreateCorrectExpiryDate()
     {
         // Arrange
-        var date = new DateTime(2023, 12, 1);
-        var expiryDate = new ExpiryDate(date);
+        var values = (Month: 6, Year: 2024);
 
         // Act
-        var formattedPtBr = expiryDate.Formatted_ptBr();
+        ExpiryDate expiryDate = values;
 
         // Assert
-        Assert.Equal("12/23", formattedPtBr);
+        Assert.Equal(6, expiryDate.Month);
+        Assert.Equal(2024, expiryDate.Year);
+        Assert.Equal(new DateTime(2024, 6, 1), expiryDate.Value);
+    }
+
+    [Fact]
+    public void ConstructorWithTuple_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var values = (Month: 6, Year: 2024);
+
+        // Act
+        var expiryDate = new ExpiryDate(values);
+
+        // Assert
+        Assert.Equal(6, expiryDate.Month);
+        Assert.Equal(2024, expiryDate.Year);
+        Assert.Equal(new DateTime(2024, 6, 1), expiryDate.Value);
+    }
+
+    [Fact]
+    public async Task Formatted_ptBr_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        var expiryDate = new ExpiryDate(new DateTime(2024, 6, 27));
+        var originalCulture = CultureInfo.CurrentCulture;
+
+        CultureInfo.CurrentCulture = new CultureInfo("pt-BR");
+
+        try
+        {
+            // Act
+            var formatted = await Task.Run(() => expiryDate.Formatted_ptBr());
+
+            // Assert
+            Assert.Equal("06/24", formatted);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void ConstructorWithDateTime_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var date = new DateTime(2024, 6, 27);
+
+        // Act
+        var expiryDate = new ExpiryDate(date);
+
+        // Assert
+        Assert.Equal(6, expiryDate.Month);
+        Assert.Equal(2024, expiryDate.Year);
+        Assert.Equal(date, expiryDate.Value);
     }
 }

--- a/LiteStreaming.XUnitTest/Domain/Transactions/ValueObject/ExpiryDateTest.cs
+++ b/LiteStreaming.XUnitTest/Domain/Transactions/ValueObject/ExpiryDateTest.cs
@@ -34,21 +34,6 @@ public class ExpiryDateTests
     }
 
     [Fact]
-    public void ConstructorWithTuple_ShouldInitializeCorrectly()
-    {
-        // Arrange
-        var values = (Month: 6, Year: 2024);
-
-        // Act
-        var expiryDate = new ExpiryDate(values);
-
-        // Assert
-        Assert.Equal(6, expiryDate.Month);
-        Assert.Equal(2024, expiryDate.Year);
-        Assert.Equal(new DateTime(2024, 6, 1), expiryDate.Value);
-    }
-
-    [Fact]
     public async Task Formatted_ptBr_ShouldReturnCorrectFormat()
     {
         // Arrange


### PR DESCRIPTION
### Para  solução do problema de recursividade em loop foi criado um método construtor para a operação de comparação implícita. ```Private ExpiryDate((int Month, int Year) values)```


```csharp
using System.ComponentModel.DataAnnotations.Schema;

namespace Domain.Transactions.ValueObject;
public record ExpiryDate
{
    public static implicit operator (int Month, int Year)(ExpiryDate expiryDate) => (expiryDate.Month, expiryDate.Year);
    public static implicit operator ExpiryDate((int Month, int Year) values) => new ExpiryDate(values);

    public DateTime Value { get; set; }

    [NotMapped]
    public int Month { get; init; }

    [NotMapped]
    public int Year { get; init; }

    public ExpiryDate(DateTime value)
    {
        Value = value;
        Month = value.Month;
        Year = value.Year;
    }

    private ExpiryDate((int Month, int Year) values) : this(new DateTime(values.Year, values.Month, 1, 0, 0, 0, DateTimeKind.Local))
    {
        Month = values.Month;
        Year = values.Year;
    }

    public string Formatted_ptBr()
    {
        return $"{Value.Month:D2}/{Value.Year % 100:D2}";
    }
}
```

### E para validação dos teste unitários prevendo problemas de execução em diferentes  ambientes como "Windows/Linux"  e com configurações padrão de CultureInfo e  fusos horários variados, o Teste unitário foi criado como Task para não prejudicar outros testes em execução paralela com as configurações de CultureInfo modificadas neste teste unitário

```csharp
[Fact]
public async Task Formatted_ptBr_ShouldReturnCorrectFormat()
{
    // Arrange
    var expiryDate = new ExpiryDate(new DateTime(2024, 6, 27));
    var originalCulture = CultureInfo.CurrentCulture;

    CultureInfo.CurrentCulture = new CultureInfo("pt-BR");

    try
    {
        // Act
        var formatted = await Task.Run(() => expiryDate.Formatted_ptBr());

        // Assert
        Assert.Equal("06/24", formatted);
    }
    finally
    {
        CultureInfo.CurrentCulture = originalCulture;
    }
}
```